### PR TITLE
Fix link to w3c polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Intersection Observer Polyfill
 
-**IMPORTANT:** I'm not going to work on this polyfill since the WICG repository contains another one closest and more up-to-date according to the officla spec. I recommend using that one: https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill
+**IMPORTANT:** I'm not going to work on this polyfill since the WICG repository contains another one closest and more up-to-date according to the officla spec. I recommend using that one: https://github.com/w3c/IntersectionObserver/tree/master/polyfill
 
 The IntersectionObserver API allows the developer to detect the intersection between a DOM elements and a reference element or the viewport.
 


### PR DESCRIPTION
The file that was being linked to no longer exists.